### PR TITLE
Add Navigation Bar Padding and Version Update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
   val MAJOR = 1
   val MINOR = 0
-  val PATCH = 0
+  val PATCH = 1
 
   defaultConfig {
     applicationId = "app.cardnest"

--- a/app/src/main/java/app/cardnest/AppViewModel.kt
+++ b/app/src/main/java/app/cardnest/AppViewModel.kt
@@ -21,8 +21,8 @@ import app.cardnest.screens.pin.unlock.UnlockWithPinScreen
 import app.cardnest.screens.user.app_info.updates.UpdatesState
 import app.cardnest.utils.extensions.launchDefault
 import app.cardnest.utils.extensions.launchWithIO
+import app.cardnest.utils.extensions.log
 import app.cardnest.utils.extensions.stateInViewModel
-import app.cardnest.utils.extensions.toastAndLog
 import app.cardnest.utils.updates.UpdatesManager
 import app.cardnest.utils.updates.UpdatesResult
 import cafe.adriel.voyager.core.screen.Screen
@@ -92,7 +92,7 @@ class AppViewModel(private val userManager: UserManager, private val authManager
 
           updatesState.update { state }
         } catch (e: Exception) {
-          e.toastAndLog("UpdatesViewModel")
+          e.log("AppViewModel")
         }
       }
     }

--- a/app/src/main/java/app/cardnest/components/bottomSheet/BottomSheet.kt
+++ b/app/src/main/java/app/cardnest/components/bottomSheet/BottomSheet.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -31,7 +32,10 @@ fun BottomSheet(content: @Composable ColumnScope. () -> Unit) {
     Column(
       content = content,
       horizontalAlignment = Alignment.CenterHorizontally,
-      modifier = Modifier.padding(top = 1.dp).background(appGradient, RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)).padding(16.dp),
+      modifier = Modifier.padding(top = 1.dp).background(
+        appGradient,
+        RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+      ).padding(16.dp).navigationBarsPadding(),
     )
   }
 }

--- a/app/src/main/java/app/cardnest/components/containers/Screen.kt
+++ b/app/src/main/java/app/cardnest/components/containers/Screen.kt
@@ -3,7 +3,12 @@ package app.cardnest.components.containers
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.areNavigationBarsVisible
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -32,6 +37,7 @@ fun TabScreenRoot(content: @Composable ColumnScope.() -> Unit) {
     content = content,
     modifier = Modifier
       .statusBarsPadding()
+      .navigationBarsPadding()
       .padding(bottom = 56.dp)
       .fillMaxHeight()
       .verticalScroll(rememberScrollState(0))
@@ -69,17 +75,23 @@ fun SubScreenRoot(title: String, backLabel: String = "Back", spacedBy: Dp? = nul
   }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun SubScreenRoot(content: @Composable ColumnScope.() -> Unit) {
-  Column(Modifier.fillMaxHeight(), content = content)
+  Column(Modifier.fillMaxHeight()) {
+    content()
+    if (WindowInsets.areNavigationBarsVisible) {
+      Spacer(Modifier.navigationBarsPadding())
+    }
+  }
 }
 
 @Composable
-fun SubScreenContainer(spacedBy: Dp? = null, content: @Composable ColumnScope.() -> Unit) {
-  ScreenContainer(spacedBy, Modifier.fillMaxHeight().verticalScroll(rememberScrollState()), content)
+fun ColumnScope.SubScreenContainer(spacedBy: Dp? = null, content: @Composable ColumnScope.() -> Unit) {
+  ScreenContainer(spacedBy, Modifier.weight(1f).verticalScroll(rememberScrollState()), content)
 }
 
 @Composable
-fun ScreenContainer(spacedBy: Dp? = null, modifier: Modifier = Modifier, content: @Composable ColumnScope.() -> Unit) {
+fun ColumnScope.ScreenContainer(spacedBy: Dp? = null, modifier: Modifier = Modifier, content: @Composable ColumnScope.() -> Unit) {
   Column(modifier.padding(16.dp), if (spacedBy != null) Arrangement.spacedBy(spacedBy) else Arrangement.Top, content = content)
 }

--- a/app/src/main/java/app/cardnest/components/tabs/Tab.kt
+++ b/app/src/main/java/app/cardnest/components/tabs/Tab.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
@@ -60,7 +61,7 @@ fun BoxScope.TabBar(show: Boolean) {
 
   Box(Modifier.align(Alignment.BottomCenter)) {
     AnimatedVisibility(show, enter = slideInVertically { it }, exit = slideOutVertically { it }) {
-      Column(Modifier.background(TH_BLACK)) {
+      Column(Modifier.background(TH_BLACK).navigationBarsPadding()) {
         HorizontalDivider(thickness = 0.5.dp, color = TH_WHITE_10)
 
         Row {

--- a/app/src/main/java/app/cardnest/components/toast/AppToast.kt
+++ b/app/src/main/java/app/cardnest/components/toast/AppToast.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -53,7 +54,12 @@ fun BoxScope.AppToast() {
     AppToastType.ERROR -> TH_RED
   }
 
-  AnimatedVisibility(state.show, Modifier.align(Alignment.BottomCenter).padding(start = 16.dp, end = 16.dp, bottom = 72.dp), enter, exit) {
+  AnimatedVisibility(
+    state.show,
+    Modifier.align(Alignment.BottomCenter).navigationBarsPadding().padding(start = 16.dp, end = 16.dp, bottom = 72.dp),
+    enter,
+    exit
+  ) {
     Box(Modifier.background(TH_BLACK, RoundedCornerShape(10.dp)), Alignment.Center) {
       Row(Modifier.padding(horizontal = 14.dp, vertical = 8.dp), verticalAlignment = Alignment.CenterVertically) {
         ToastIcon(state.type)


### PR DESCRIPTION
This update includes several enhancements and fixes:

- Added padding to various UI components (screens, `BottomSheet`, and `Toast`) to account for the navigation bar.
- Removed the error toast displayed during update checks at launch to improve user experience.
- Updated the app version to `1.0.1` to reflect these changes.